### PR TITLE
Minor Optimizations

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"io"
 	"strconv"
 	"strings"
 
@@ -9,7 +10,7 @@ import (
 	ase "github.com/aerospike/aerospike-client-go/types"
 )
 
-func cmdDEL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdDEL(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -24,7 +25,7 @@ func cmdDEL(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":0")
 }
 
-func get(wf writeFunc, ctx *context, k []byte, binName string) error {
+func get(wf io.Writer, ctx *context, k []byte, binName string) error {
 	key, err := buildKey(ctx, k)
 	if err != nil {
 		return err
@@ -36,11 +37,11 @@ func get(wf writeFunc, ctx *context, k []byte, binName string) error {
 	return writeBin(wf, rec, binName, "$-1")
 }
 
-func cmdGET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdGET(wf io.Writer, ctx *context, args [][]byte) error {
 	return get(wf, ctx, args[0], binName)
 }
 
-func cmdMGET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdMGET(wf io.Writer, ctx *context, args [][]byte) error {
 	res := make([]*as.Record, len(args))
 	for i := 0; i < len(args); i++ {
 		key, err := buildKey(ctx, args[i])
@@ -56,11 +57,11 @@ func cmdMGET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeArrayBin(wf, res, binName, "")
 }
 
-func cmdHGET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHGET(wf io.Writer, ctx *context, args [][]byte) error {
 	return get(wf, ctx, args[0], string(args[1]))
 }
 
-func setex(wf writeFunc, ctx *context, k []byte, binName string, content []byte, ttl int, createOnly bool) error {
+func setex(wf io.Writer, ctx *context, k []byte, binName string, content []byte, ttl int, createOnly bool) error {
 	key, err := buildKey(ctx, k)
 	if err != nil {
 		return err
@@ -81,11 +82,11 @@ func setex(wf writeFunc, ctx *context, k []byte, binName string, content []byte,
 	return writeLine(wf, "+OK")
 }
 
-func cmdSET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdSET(wf io.Writer, ctx *context, args [][]byte) error {
 	return setex(wf, ctx, args[0], binName, args[1], -1, false)
 }
 
-func cmdSETEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdSETEX(wf io.Writer, ctx *context, args [][]byte) error {
 	ttl, err := strconv.Atoi(string(args[1]))
 	if err != nil {
 		return err
@@ -93,7 +94,7 @@ func cmdSETEX(wf writeFunc, ctx *context, args [][]byte) error {
 	return setex(wf, ctx, args[0], binName, args[2], ttl, false)
 }
 
-func cmdMSET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdMSET(wf io.Writer, ctx *context, args [][]byte) error {
 	for i := 0; i+1 < len(args); i += 2 {
 		key, err := buildKey(ctx, args[i])
 		if err != nil {
@@ -110,11 +111,11 @@ func cmdMSET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, "+OK")
 }
 
-func cmdSETNX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdSETNX(wf io.Writer, ctx *context, args [][]byte) error {
 	return setex(wf, ctx, args[0], binName, args[1], -1, true)
 }
 
-func cmdSETNXEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdSETNXEX(wf io.Writer, ctx *context, args [][]byte) error {
 	ttl, err := strconv.Atoi(string(args[1]))
 	if err != nil {
 		return err
@@ -123,7 +124,7 @@ func cmdSETNXEX(wf writeFunc, ctx *context, args [][]byte) error {
 	return setex(wf, ctx, args[0], binName, args[2], ttl, true)
 }
 
-func cmdHSET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHSET(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -135,7 +136,7 @@ func cmdHSET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":"+strconv.Itoa(rec.(int)))
 }
 
-func cmdHDEL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHDEL(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -147,7 +148,7 @@ func cmdHDEL(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":"+strconv.Itoa(rec.(int)))
 }
 
-func arrayPush(wf writeFunc, ctx *context, args [][]byte, f string, ttl int) error {
+func arrayPush(wf io.Writer, ctx *context, args [][]byte, f string, ttl int) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -159,11 +160,11 @@ func arrayPush(wf writeFunc, ctx *context, args [][]byte, f string, ttl int) err
 	return writeLine(wf, ":"+strconv.Itoa(rec.(int)))
 }
 
-func cmdRPUSH(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdRPUSH(wf io.Writer, ctx *context, args [][]byte) error {
 	return arrayPush(wf, ctx, args, "RPUSH", -1)
 }
 
-func cmdRPUSHEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdRPUSHEX(wf io.Writer, ctx *context, args [][]byte) error {
 	ttl, err := strconv.Atoi(string(args[2]))
 	if err != nil {
 		return err
@@ -172,11 +173,11 @@ func cmdRPUSHEX(wf writeFunc, ctx *context, args [][]byte) error {
 	return arrayPush(wf, ctx, args, "RPUSH", ttl)
 }
 
-func cmdLPUSH(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdLPUSH(wf io.Writer, ctx *context, args [][]byte) error {
 	return arrayPush(wf, ctx, args, "LPUSH", -1)
 }
 
-func cmdLPUSHEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdLPUSHEX(wf io.Writer, ctx *context, args [][]byte) error {
 	ttl, err := strconv.Atoi(string(args[2]))
 	if err != nil {
 		return err
@@ -185,7 +186,7 @@ func cmdLPUSHEX(wf writeFunc, ctx *context, args [][]byte) error {
 	return arrayPush(wf, ctx, args, "LPUSH", ttl)
 }
 
-func arrayPop(wf writeFunc, ctx *context, args [][]byte, f string) error {
+func arrayPop(wf io.Writer, ctx *context, args [][]byte, f string) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -222,15 +223,15 @@ func arrayPop(wf writeFunc, ctx *context, args [][]byte, f string) error {
 	}
 }
 
-func cmdRPOP(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdRPOP(wf io.Writer, ctx *context, args [][]byte) error {
 	return arrayPop(wf, ctx, args, "RPOP")
 }
 
-func cmdLPOP(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdLPOP(wf io.Writer, ctx *context, args [][]byte) error {
 	return arrayPop(wf, ctx, args, "LPOP")
 }
 
-func cmdLLEN(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdLLEN(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -242,7 +243,7 @@ func cmdLLEN(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeBinInt(wf, rec, binName+"_size")
 }
 
-func cmdLRANGE(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdLRANGE(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -265,7 +266,7 @@ func cmdLRANGE(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeArray(wf, rec.([]interface{}))
 }
 
-func cmdLTRIM(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdLTRIM(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -288,7 +289,7 @@ func cmdLTRIM(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, "+OK")
 }
 
-func hIncrByEx(wf writeFunc, ctx *context, k []byte, field string, incr int, ttl int) error {
+func hIncrByEx(wf io.Writer, ctx *context, k []byte, field string, incr int, ttl int) error {
 	key, err := buildKey(ctx, k)
 	if err != nil {
 		return err
@@ -304,15 +305,15 @@ func hIncrByEx(wf writeFunc, ctx *context, k []byte, field string, incr int, ttl
 	return writeBinInt(wf, rec, field)
 }
 
-func cmdINCR(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdINCR(wf io.Writer, ctx *context, args [][]byte) error {
 	return hIncrByEx(wf, ctx, args[0], binName, 1, -1)
 }
 
-func cmdDECR(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdDECR(wf io.Writer, ctx *context, args [][]byte) error {
 	return hIncrByEx(wf, ctx, args[0], binName, -1, -1)
 }
 
-func cmdINCRBY(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdINCRBY(wf io.Writer, ctx *context, args [][]byte) error {
 	incr, err := strconv.Atoi(string(args[1]))
 	if err != nil {
 		return err
@@ -320,7 +321,7 @@ func cmdINCRBY(wf writeFunc, ctx *context, args [][]byte) error {
 	return hIncrByEx(wf, ctx, args[0], binName, incr, -1)
 }
 
-func cmdHINCRBY(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHINCRBY(wf io.Writer, ctx *context, args [][]byte) error {
 	incr, err := strconv.Atoi(string(args[2]))
 	if err != nil {
 		return err
@@ -328,7 +329,7 @@ func cmdHINCRBY(wf writeFunc, ctx *context, args [][]byte) error {
 	return hIncrByEx(wf, ctx, args[0], string(args[1]), incr, -1)
 }
 
-func cmdHINCRBYEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHINCRBYEX(wf io.Writer, ctx *context, args [][]byte) error {
 	incr, err := strconv.Atoi(string(args[2]))
 	if err != nil {
 		return err
@@ -340,7 +341,7 @@ func cmdHINCRBYEX(wf writeFunc, ctx *context, args [][]byte) error {
 	return hIncrByEx(wf, ctx, args[0], string(args[1]), incr, ttl)
 }
 
-func cmdDECRBY(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdDECRBY(wf io.Writer, ctx *context, args [][]byte) error {
 	decr, err := strconv.Atoi(string(args[1]))
 	if err != nil {
 		return err
@@ -348,7 +349,7 @@ func cmdDECRBY(wf writeFunc, ctx *context, args [][]byte) error {
 	return hIncrByEx(wf, ctx, args[0], binName, -decr, -1)
 }
 
-func cmdHMGET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHMGET(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -374,7 +375,7 @@ func cmdHMGET(wf writeFunc, ctx *context, args [][]byte) error {
 	return nil
 }
 
-func cmdHMSET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHMSET(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -390,7 +391,7 @@ func cmdHMSET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, "+"+rec.(string))
 }
 
-func cmdHGETALL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHGETALL(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -417,7 +418,7 @@ func cmdHGETALL(wf writeFunc, ctx *context, args [][]byte) error {
 	return nil
 }
 
-func cmdEXPIRE(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdEXPIRE(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -438,7 +439,7 @@ func cmdEXPIRE(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":1")
 }
 
-func cmdTTL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdTTL(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err
@@ -454,7 +455,7 @@ func cmdTTL(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":"+strconv.FormatUint(uint64(rec.Expiration), 10))
 }
 
-func cmdFLUSHDB(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdFLUSHDB(wf io.Writer, ctx *context, args [][]byte) error {
 	recordset, err := ctx.client.ScanAll(nil, ctx.ns, ctx.set)
 	if err != nil {
 		return err
@@ -478,7 +479,7 @@ func cmdFLUSHDB(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, "+OK")
 }
 
-func cmdHMINCRBYEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdHMINCRBYEX(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := buildKey(ctx, args[0])
 	if err != nil {
 		return err

--- a/expanded_map.go
+++ b/expanded_map.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"math/rand"
 	"strconv"
 	"time"
@@ -104,7 +105,7 @@ func _compositeExistsOrCreate(ctx *context, k string, ttl int, canRetry bool) (*
 	return &kk, true, nil
 }
 
-func cmdExpandedMapHGET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHGET(wf io.Writer, ctx *context, args [][]byte) error {
 	suffixedKey, err := compositeExists(ctx, string(args[0]))
 	if err != nil {
 		return err
@@ -124,7 +125,7 @@ func cmdExpandedMapHGET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeBin(wf, rec, VALUE_BIN_NAME, "$-1")
 }
 
-func cmdExpandedMapHSET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHSET(wf io.Writer, ctx *context, args [][]byte) error {
 	suffixedKey, _, err := compositeExistsOrCreate(ctx, string(args[0]), -1)
 	if err != nil {
 		return err
@@ -153,7 +154,7 @@ func cmdExpandedMapHSET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":1")
 }
 
-func cmdExpandedMapHDEL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHDEL(wf io.Writer, ctx *context, args [][]byte) error {
 	suffixedKey, err := compositeExists(ctx, string(args[0]))
 	if err != nil {
 		return err
@@ -175,7 +176,7 @@ func cmdExpandedMapHDEL(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, ":0")
 }
 
-func cmdExpandedMapEXPIRE(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapEXPIRE(wf io.Writer, ctx *context, args [][]byte) error {
 	ttl, err := strconv.Atoi(string(args[1]))
 	if err != nil {
 		return err
@@ -194,7 +195,7 @@ func cmdExpandedMapEXPIRE(wf writeFunc, ctx *context, args [][]byte) error {
 	return cmdEXPIRE(wf, ctx, args)
 }
 
-func cmdExpandedMapTTL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapTTL(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := formatCompositeKey(ctx, string(args[0]), MAIN_SUFFIX)
 	if err != nil {
 		return err
@@ -209,7 +210,7 @@ func cmdExpandedMapTTL(wf writeFunc, ctx *context, args [][]byte) error {
 	return cmdTTL(wf, ctx, args)
 }
 
-func cmdExpandedMapDEL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapDEL(wf io.Writer, ctx *context, args [][]byte) error {
 	key, err := formatCompositeKey(ctx, string(args[0]), MAIN_SUFFIX)
 	if err != nil {
 		return err
@@ -227,7 +228,7 @@ func cmdExpandedMapDEL(wf writeFunc, ctx *context, args [][]byte) error {
 	return cmdDEL(wf, ctx, args)
 }
 
-func cmdExpandedMapHMSET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHMSET(wf io.Writer, ctx *context, args [][]byte) error {
 	suffixedKey, _, err := compositeExistsOrCreate(ctx, string(args[0]), -1)
 	if err != nil {
 		return err
@@ -251,7 +252,7 @@ func cmdExpandedMapHMSET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeLine(wf, "+OK")
 }
 
-func cmdExpandedMapHMGET(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHMGET(wf io.Writer, ctx *context, args [][]byte) error {
 	suffixedKey, err := compositeExists(ctx, string(args[0]))
 	if err != nil {
 		return err
@@ -273,7 +274,7 @@ func cmdExpandedMapHMGET(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeArrayBin(wf, res, VALUE_BIN_NAME, "")
 }
 
-func cmdExpandedMapHGETALL(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHGETALL(wf io.Writer, ctx *context, args [][]byte) error {
 	suffixedKey, err := compositeExists(ctx, string(args[0]))
 	if err != nil {
 		return err
@@ -297,7 +298,7 @@ func cmdExpandedMapHGETALL(wf writeFunc, ctx *context, args [][]byte) error {
 	return writeArrayBin(wf, out, VALUE_BIN_NAME, SECOND_KEY_BIN_NAME)
 }
 
-func compositeIncr(wf writeFunc, ctx *context, suffixedKey *string, field string, value int) error {
+func compositeIncr(wf io.Writer, ctx *context, suffixedKey *string, field string, value int) error {
 	key, err := formatCompositeKey(ctx, *suffixedKey, field)
 	if err != nil {
 		return err
@@ -312,7 +313,7 @@ func compositeIncr(wf writeFunc, ctx *context, suffixedKey *string, field string
 	return writeBinInt(wf, rec, VALUE_BIN_NAME)
 }
 
-func cmdExpandedMapHINCRBYEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHINCRBYEX(wf io.Writer, ctx *context, args [][]byte) error {
 	incr, err := strconv.Atoi(string(args[2]))
 	if err != nil {
 		return err
@@ -328,7 +329,7 @@ func cmdExpandedMapHINCRBYEX(wf writeFunc, ctx *context, args [][]byte) error {
 	return compositeIncr(wf, ctx, suffixedKey, string(args[1]), incr)
 }
 
-func cmdExpandedMapHINCRBY(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHINCRBY(wf io.Writer, ctx *context, args [][]byte) error {
 	incr, err := strconv.Atoi(string(args[2]))
 	if err != nil {
 		return err
@@ -340,7 +341,7 @@ func cmdExpandedMapHINCRBY(wf writeFunc, ctx *context, args [][]byte) error {
 	return compositeIncr(wf, ctx, suffixedKey, string(args[1]), incr)
 }
 
-func cmdExpandedMapHMINCRBYEX(wf writeFunc, ctx *context, args [][]byte) error {
+func cmdExpandedMapHMINCRBYEX(wf io.Writer, ctx *context, args [][]byte) error {
 	ttl, err := strconv.Atoi(string(args[1]))
 	if err != nil {
 		return err

--- a/protocol.go
+++ b/protocol.go
@@ -1,87 +1,43 @@
 package main
 
 import (
+	"bufio"
 	"errors"
-	"net"
+	"io"
 	"strconv"
 )
 
-type readingContext struct {
-	conn  net.Conn
-	buf   []byte
-	start int
-	end   int
-}
-
-func readLine(ctx *readingContext, prefix []byte) ([]byte, error) {
-	if prefix != nil && prefix[len(prefix)-1] == '\r' && ctx.start == 0 && ctx.buf[0] == '\n' {
-		ctx.start = 1
-		return prefix[0 : len(prefix)-1], nil
-	}
-	for i := ctx.start; i < ctx.end; i++ {
-		if i < ctx.end-1 && ctx.buf[i] == '\r' && ctx.buf[i+1] == '\n' {
-			line := ctx.buf[ctx.start:i]
-			if prefix != nil {
-				line = append(prefix, line...)
-			}
-			ctx.start = i + 2
-			return line, nil
-		}
-		if ctx.buf[i] == '\n' {
-			line := ctx.buf[ctx.start:i]
-			if prefix != nil {
-				line = append(prefix, line...)
-			}
-			ctx.start = i + 1
-			return line, nil
-		}
-	}
-
-	if ctx.start == ctx.end {
-		ctx.start = 0
-		ctx.end = 0
-	}
-	if ctx.end == len(ctx.buf) {
-		current := ctx.buf[ctx.start:]
-		ctx.start = 0
-		ctx.end = 0
-		line, err := readLine(ctx, current)
-		if err != nil {
-			return nil, err
-		}
-		return line, nil
-	}
-	l, err := ctx.conn.Read(ctx.buf[ctx.end:])
+func readLine(ctx *bufio.Reader, prefix []byte) ([]byte, error) {
+	line, isPrefix, err := ctx.ReadLine()
 	if err != nil {
 		return nil, err
 	}
-	ctx.end += l
-	return readLine(ctx, prefix)
-}
 
-func readByteArray(ctx *readingContext, size int) ([]byte, error) {
-	if ctx.start+size+2 > ctx.end {
-		size += 2
-		localBuf := make([]byte, size)
-		copy(localBuf, ctx.buf[ctx.start:ctx.end])
-		current := ctx.end - ctx.start
-		for current < size {
-			l, err := ctx.conn.Read(localBuf[current:])
-			if err != nil {
-				return nil, err
-			}
-			current += l
-		}
-		ctx.start = 0
-		ctx.end = 0
-		return localBuf[:size-2], nil
+	if len(prefix) > 0 {
+		line = append(prefix, line...)
 	}
-	res := ctx.buf[ctx.start : ctx.start+size]
-	ctx.start += size + 2
-	return res, nil
+
+	if isPrefix {
+		return readLine(ctx, line)
+	}
+
+	return line, nil
 }
 
-func parse(ctx *readingContext) ([][]byte, error) {
+func readByteArray(ctx *bufio.Reader, size int) ([]byte, error) {
+	// read the \r\n as well
+	size += 2
+	res := make([]byte, size)
+	n, err := io.ReadFull(ctx, res)
+	if n != size {
+		return nil, errors.New("protocol parse error: byte array size mismatch")
+	}
+
+	// don't return the \r\n
+	return res[:size-2], err
+}
+
+func parse(ctx *bufio.Reader) ([][]byte, error) {
 	line, err := readLine(ctx, nil)
 	if err != nil {
 		return nil, err

--- a/redis.go
+++ b/redis.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -101,6 +102,9 @@ func displayExpandedMapCacheStat(ctx *context) {
 }
 
 func main() {
+	// to change the flags on the default logger
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
 	rand.Seed(time.Now().UnixNano())
 
 	aeroHost := flag.String("aero_host", "localhost", "Aerospike server host")
@@ -319,9 +323,9 @@ func handleConnection(conn net.Conn, handlers map[string]handler, ctx *context) 
 		conn.Close()
 		return nil
 	}
-	readingCtx := readingContext{conn, make([]byte, 1024), 0, 0}
+	readingCtx := bufio.NewReader(conn)
 	for {
-		args, err := parse(&readingCtx)
+		args, err := parse(readingCtx)
 		if err != nil {
 			if err == io.EOF {
 				return onError()

--- a/redis.lua
+++ b/redis.lua
@@ -18,6 +18,10 @@ local function UPDATE(rec)
 	end
 end
 
+function DELETE(rec)
+	aerospike:remove(rec)
+end
+
 function LPOP(rec, bin, count, ttl)
 	if (EXISTS(rec, bin)) then
 		local l = rec[bin]

--- a/structs.go
+++ b/structs.go
@@ -1,15 +1,15 @@
 package main
 
 import (
+	"io"
+
 	as "github.com/aerospike/aerospike-client-go"
 	"github.com/coocood/freecache"
 )
 
-type writeFunc func([]byte) error
-
 type handler struct {
 	argsCount int
-	f         func(writeFunc, *context, [][]byte) error
+	f         func(io.Writer, *context, [][]byte) error
 }
 
 type context struct {

--- a/write_back.go
+++ b/write_back.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net"
 	"strconv"
@@ -28,7 +29,7 @@ func writeBack(handlers map[string]handler, config map[string]interface{}, ctx *
 		a := make([]interface{}, 2)
 		m["args"] = a
 		log.Printf("%s: Using write back for setTimeout to %s", ctx.set, config["write_back_target"])
-		f := func(wf writeFunc, ctx *context, args [][]byte) error {
+		f := func(wf io.Writer, ctx *context, args [][]byte) error {
 			key := string(args[0])
 			ttl, err := strconv.Atoi(string(args[1]))
 			if err != nil {
@@ -54,7 +55,7 @@ func writeBack(handlers map[string]handler, config map[string]interface{}, ctx *
 		a := make([]interface{}, 3)
 		m["args"] = a
 		log.Printf("%s: Using write back for hIncrBy to %s", ctx.set, config["write_back_target"])
-		f := func(wf writeFunc, ctx *context, args [][]byte) error {
+		f := func(wf io.Writer, ctx *context, args [][]byte) error {
 			key := string(args[0])
 			field := string(args[1])
 			incr, err := strconv.Atoi(string(args[2]))


### PR DESCRIPTION
- Idiomatic Buffer Management
- Use general `io.Writer` instead of `writerFunc` and closures to avoid allocating memory
- Use server-side UDF delete for `flushdb` command